### PR TITLE
Correct typo in Griffith Observatory description

### DIFF
--- a/museums.yaml
+++ b/museums.yaml
@@ -2022,7 +2022,7 @@
 
     Griffith Jenkins Griffith was a Welsh-American who made money through mining syndicates during the California gold rush, trading on his expertise as a journalist covering mining for the Alta California newspaper.
 
-    After moving to Los Angeles in 1882 he married Tina Mesmer, the air to the quarter million dollar Briswalter fortune... but only after ensuring that the entire fortune would be transferred to his name.
+    After moving to Los Angeles in 1882 he married Tina Mesmer, the heir to the quarter million dollar Briswalter fortune... but only after ensuring that the entire fortune would be transferred to his name.
 
     He used his wife's money to climb the ranks of LA society, building a reputation as a philanthropist through the donation in 1896 of 3,015 acres of ranch land to the city for use as a public park - Griffith Park.
 


### PR DESCRIPTION
Corrected typo in Griffith Observatory description.