### PR TITLE
Add museums JSON export endpoint via Datasette plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+browse.db

--- a/plugins/export.py
+++ b/plugins/export.py
@@ -1,0 +1,30 @@
+from datasette import hookimpl, Response
+
+
+async def museums_json(request, datasette):
+    db = datasette.get_database("browse")
+    result = await db.execute(
+        """
+        select
+            name,
+            'https://www.niche-museums.com/' || id as url,
+            address,
+            description,
+            photo_url,
+            photo_alt,
+            created
+        from
+            museums
+        order by
+            id
+        """
+    )
+    museums = [dict(row) for row in result.rows]
+    return Response.json(museums)
+
+
+@hookimpl
+def register_routes():
+    return [
+        (r"^/museums\.json$", museums_json),
+    ]


### PR DESCRIPTION
> Add a new route /museums.json which returns a JSON response that is an array of objects from
> this SQL query
> 
> select
> name,
> 'https://www.niche-museums.com/' || id as url,
> address,
> description,
> photo_url,
> photo_alt,
> created
> from
> museums
> order by
> id
> 
> Put this in plugins/export.py using register routes
> 
> Test it locally using curl

## Summary
This PR adds a new Datasette plugin that exposes museum data as a JSON API endpoint, allowing external access to the museums database in a structured format.

## Key Changes
- **New plugin file** (`plugins/export.py`): Implements a Datasette plugin that registers a `/museums.json` route
  - Queries the `museums` table from the `browse` database
  - Constructs full URLs for each museum using the niche-museums.com domain
  - Returns all museums as a JSON array, ordered by ID
  - Includes museum metadata: name, URL, address, description, photo details, and creation date
- **Updated .gitignore**: Added `browse.db` to prevent committing the local SQLite database file

## Implementation Details
- Uses Datasette's `@hookimpl` decorator to register the custom route
- Leverages Datasette's built-in `Response.json()` for proper JSON serialization
- Constructs museum URLs dynamically by concatenating the base domain with the museum ID
- Returns results as a list of dictionaries for clean JSON representation

https://claude.ai/code/session_011kYF5RBmnfRQzjC9qdt8Wy